### PR TITLE
Simplify dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
 FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel 
 
-# ARG PYTORCH_VERSION=2.4.0
-# ARG PYTHON_VERSION=3.9
-# ARG CUDA_VERSION=12.1
-# ARG MAMBA_VERSION=24.3.0-0
-# ARG CUDA_CHANNEL=nvidia
-# ARG INSTALL_CHANNEL=pytorch
-# Automatically set by buildx
 ARG TARGETPLATFORM
 
 ENV PATH=/opt/conda/bin:$PATH
@@ -18,26 +11,6 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
         curl \
         git && \
         rm -rf /var/lib/apt/lists/*
-
-# Install conda
-# translating Docker's TARGETPLATFORM into mamba arches
-# RUN case ${TARGETPLATFORM} in \
-#          "linux/arm64")  MAMBA_ARCH=aarch64  ;; \
-#          *)              MAMBA_ARCH=x86_64   ;; \
-#     esac && \
-#     curl -fsSL -v -o ~/mambaforge.sh -O  "https://github.com/conda-forge/miniforge/releases/download/${MAMBA_VERSION}/Mambaforge-${MAMBA_VERSION}-Linux-${MAMBA_ARCH}.sh"
-# RUN chmod +x ~/mambaforge.sh && \
-#     bash ~/mambaforge.sh -b -p /opt/conda && \
-#     rm ~/mambaforge.sh
-
-# Install pytorch
-# On arm64 we exit with an error code
-# RUN case ${TARGETPLATFORM} in \
-#          "linux/arm64")  exit 1 ;; \
-#          *)              /opt/conda/bin/conda update -y conda &&  \
-#                          /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y "python=${PYTHON_VERSION}" "pytorch=$PYTORCH_VERSION" "pytorch-cuda=$(echo $CUDA_VERSION | cut -d'.' -f 1-2)"  ;; \
-#     esac && \
-#     /opt/conda/bin/conda clean -ya
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-devel 
 
-ARG PYTORCH_VERSION=2.4.0
-ARG PYTHON_VERSION=3.9
-ARG CUDA_VERSION=12.1
-ARG MAMBA_VERSION=24.3.0-0
-ARG CUDA_CHANNEL=nvidia
-ARG INSTALL_CHANNEL=pytorch
+# ARG PYTORCH_VERSION=2.4.0
+# ARG PYTHON_VERSION=3.9
+# ARG CUDA_VERSION=12.1
+# ARG MAMBA_VERSION=24.3.0-0
+# ARG CUDA_CHANNEL=nvidia
+# ARG INSTALL_CHANNEL=pytorch
 # Automatically set by buildx
 ARG TARGETPLATFORM
 
@@ -21,28 +21,28 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
 
 # Install conda
 # translating Docker's TARGETPLATFORM into mamba arches
-RUN case ${TARGETPLATFORM} in \
-         "linux/arm64")  MAMBA_ARCH=aarch64  ;; \
-         *)              MAMBA_ARCH=x86_64   ;; \
-    esac && \
-    curl -fsSL -v -o ~/mambaforge.sh -O  "https://github.com/conda-forge/miniforge/releases/download/${MAMBA_VERSION}/Mambaforge-${MAMBA_VERSION}-Linux-${MAMBA_ARCH}.sh"
-RUN chmod +x ~/mambaforge.sh && \
-    bash ~/mambaforge.sh -b -p /opt/conda && \
-    rm ~/mambaforge.sh
+# RUN case ${TARGETPLATFORM} in \
+#          "linux/arm64")  MAMBA_ARCH=aarch64  ;; \
+#          *)              MAMBA_ARCH=x86_64   ;; \
+#     esac && \
+#     curl -fsSL -v -o ~/mambaforge.sh -O  "https://github.com/conda-forge/miniforge/releases/download/${MAMBA_VERSION}/Mambaforge-${MAMBA_VERSION}-Linux-${MAMBA_ARCH}.sh"
+# RUN chmod +x ~/mambaforge.sh && \
+#     bash ~/mambaforge.sh -b -p /opt/conda && \
+#     rm ~/mambaforge.sh
 
 # Install pytorch
 # On arm64 we exit with an error code
-RUN case ${TARGETPLATFORM} in \
-         "linux/arm64")  exit 1 ;; \
-         *)              /opt/conda/bin/conda update -y conda &&  \
-                         /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y "python=${PYTHON_VERSION}" "pytorch=$PYTORCH_VERSION" "pytorch-cuda=$(echo $CUDA_VERSION | cut -d'.' -f 1-2)"  ;; \
-    esac && \
-    /opt/conda/bin/conda clean -ya
+# RUN case ${TARGETPLATFORM} in \
+#          "linux/arm64")  exit 1 ;; \
+#          *)              /opt/conda/bin/conda update -y conda &&  \
+#                          /opt/conda/bin/conda install -c "${INSTALL_CHANNEL}" -c "${CUDA_CHANNEL}" -y "python=${PYTHON_VERSION}" "pytorch=$PYTORCH_VERSION" "pytorch-cuda=$(echo $CUDA_VERSION | cut -d'.' -f 1-2)"  ;; \
+#     esac && \
+#     /opt/conda/bin/conda clean -ya
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
 
-RUN git clone -b energy_star_dev https://github.com/huggingface/optimum-benchmark.git /optimum-benchmark && cd optimum-benchmark && pip install -e .
+RUN git clone -b energy_star_dev https://github.com/huggingface/optimum-benchmark.git /optimum-benchmark && cd /optimum-benchmark && pip install -e .
 
 COPY ./check_h100.py /check_h100.py
 COPY ./entrypoint.sh /entrypoint.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,3 @@ diffusers==0.30.0
 huggingface-hub==0.24.5
 librosa==0.10.1
 omegaconf==2.3.0
-# optimum-benchmark @ git+https://github.com/huggingface/optimum-benchmark@energy_star_dev
-torch==2.4.0
-transformers==4.44.0


### PR DESCRIPTION
As mentioned in #5 the nvidia/cuda image referenced isn't signed while the pytorch images are so at least in the fork I was using to evaluate this project I went ahead and simplified this to resolve the errors.  The pytorch base image already included many of the subsequent steps as well as the requirements so this PR also removes thos.

I've tested the docker build and docker run on several tests now on a clean device and they work with the updated dockerfile.

Not a big deal if this departs too far from what you were intending with your docker file.
